### PR TITLE
Replaced PyQt4 with qtpy

### DIFF
--- a/fancytools/__init__.py
+++ b/fancytools/__init__.py
@@ -8,7 +8,7 @@ __email__ = 'karl@bedrich.de'
 __url__ = 'https://pypi.python.org/pypi/fancytools'
 __license__ = 'GPLv3'
 __description__ = __doc__
-__depencies__= ["numpy >= 1.9","win32com"]
+__depencies__= ["numpy >= 1.9","pywin32"]
 __classifiers__ = [
 		'Intended Audience :: Developers',
 		'Intended Audience :: Science/Research',

--- a/fancytools/utils/StreamSignal.py
+++ b/fancytools/utils/StreamSignal.py
@@ -1,5 +1,5 @@
 
-from PyQt4 import QtCore
+from qtpy import QtCore
 import sys
 
 

--- a/fancytools/utils/StreamSignal.py
+++ b/fancytools/utils/StreamSignal.py
@@ -36,7 +36,7 @@ class StreamSignal(QtCore.QObject):
     >>> l.close()
     '''
     #message = QtCore.Signal(str)# works under pyside
-    message = QtCore.pyqtSignal(str)
+    message = QtCore.Signal(str)
 
     def __init__(self, stdout='out', parent=None):
         super(StreamSignal, self).__init__(parent)


### PR DESCRIPTION
qtpy uses PyQt5/Qt5 "Rules" and is used in a well known project (SpyderIDE). Change introduces a new dependecy, but should hopefully make code more stable against major changes in Qt 5.X and potentially Qt 6
